### PR TITLE
Fix/feat: Add pagination to links API endpoints

### DIFF
--- a/services/web_api/routes/links_router.py
+++ b/services/web_api/routes/links_router.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter, Request, HTTPException, status, Depends
+from fastapi.responses import JSONResponse
 from typing import List, Optional, Dict, Any
 import logging
 import uuid
+import re
 
 from infra_core.memory_system.link_manager import (
     LinkManager,
@@ -11,11 +13,152 @@ from infra_core.memory_system.link_manager import (
 )
 from infra_core.memory_system.schemas.common import RelationType, BlockLink
 from services.web_api.models import ErrorResponse
+from pydantic import BaseModel, Field, validator
 
 # Setup logger
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["v1/Links"])
+
+# Constants
+MAX_LIMIT = 1000
+DEFAULT_LIMIT = 100
+MAX_CURSOR_LEN = 512
+
+
+class PaginatedLinksResponse(BaseModel):
+    """Response model for paginated links."""
+
+    links: List[BlockLink]
+    next_cursor: Optional[str] = None
+    page_size: int = Field(..., description="Number of items in this page")
+    total_available: Optional[int] = Field(None, description="Total count (if cheaply computable)")
+
+    @validator("links", pre=True)
+    def validate_links(cls, v):
+        """Ensure all links are properly serializable BlockLink instances."""
+        if not isinstance(v, list):
+            return v
+        # Always round-trip through model_validate to guarantee JSON serializability
+        result = []
+        for link in v:
+            if isinstance(link, BlockLink):
+                # Even if it's already a BlockLink, re-validate to ensure serializability
+                result.append(BlockLink.model_validate(link))
+            elif isinstance(link, dict):
+                result.append(BlockLink(**link))
+            else:
+                # Try to convert dataclass/object to dict then to BlockLink
+                result.append(BlockLink.model_validate(link))
+        return result
+
+
+def validate_cursor(cursor: str) -> bool:
+    """Validate cursor format - should be alphanumeric, base64url-like, max MAX_CURSOR_LEN chars."""
+    if len(cursor) > MAX_CURSOR_LEN:
+        return False
+    # Allow alphanumeric + base64url safe chars
+    return bool(re.match(r"^[A-Za-z0-9_-]+$", cursor))
+
+
+def validate_limit(limit: int) -> int:
+    """Validate and cap the limit parameter."""
+    if limit <= 0:
+        raise HTTPException(status_code=400, detail="Limit must be a positive integer")
+    if limit > MAX_LIMIT:
+        raise HTTPException(
+            status_code=400, detail=f"Limit cannot exceed {MAX_LIMIT}. Requested: {limit}"
+        )
+    return limit
+
+
+async def _paginate_links(
+    request: Request,
+    query_fn,
+    link_manager: LinkManager,
+    block_id: Optional[str] = None,
+    relation: Optional[RelationType] = None,
+    depth: Optional[int] = None,
+    direction: Optional[str] = None,
+    limit: int = DEFAULT_LIMIT,
+    cursor: Optional[str] = None,
+) -> JSONResponse:
+    """
+    Shared pagination logic for link endpoints.
+
+    Args:
+        query_fn: Either link_manager.get_all_links, .links_from, or .links_to
+        block_id: Required for .links_from and .links_to
+        other params: Standard pagination parameters
+    """
+    # Validate inputs
+    if block_id:
+        try:
+            uuid.UUID(block_id)
+        except ValueError:
+            raise HTTPException(
+                status_code=400, detail="Invalid UUID format: block_id must be a valid UUID string"
+            )
+
+    limit = validate_limit(limit)
+    if cursor and not validate_cursor(cursor):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid cursor format. Must be alphanumeric, max {MAX_CURSOR_LEN} characters",
+        )
+
+    # Validate direction if provided - fix scoping issue
+    direction_enum = None
+    if direction:
+        try:
+            direction_enum = Direction.from_string(direction)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    # Build query with provided filters
+    query = LinkQuery()
+    if relation:
+        query = query.relation(relation)
+    if depth:
+        query = query.depth(depth)
+    if direction_enum:  # Only call if direction was provided and validated
+        query = query.direction(direction_enum)
+    query = query.limit(limit)
+    if cursor:
+        query = query.cursor(cursor)
+
+    # Execute query based on function type
+    if block_id:
+        result = query_fn(block_id=block_id, query=query)
+    else:
+        result = query_fn(query=query)
+
+    # Build response
+    response_data = PaginatedLinksResponse(
+        links=result.links, next_cursor=result.next_cursor, page_size=len(result.links)
+    )
+
+    # Determine status code and headers
+    headers = {}
+    if result.next_cursor:
+        # Build next page URL with all relevant parameters
+        url_params = {"cursor": result.next_cursor, "limit": limit}
+        if relation:
+            url_params["relation"] = relation
+        if depth:
+            url_params["depth"] = depth
+        if direction:
+            url_params["direction"] = direction
+
+        next_url = str(request.url.include_query_params(**url_params))
+        headers["Link"] = f'<{next_url}>; rel="next"'
+        status_code = status.HTTP_206_PARTIAL_CONTENT
+    else:
+        status_code = status.HTTP_200_OK
+
+    return JSONResponse(
+        content=response_data.model_dump(mode="json"), status_code=status_code, headers=headers
+    )
 
 
 def get_link_manager(request: Request):
@@ -40,42 +183,51 @@ def get_link_manager(request: Request):
 
 @router.get(
     "/links",
-    response_model=List[BlockLink],
+    response_model=PaginatedLinksResponse,
     summary="Get all links",
-    description="Retrieves all links in the system, with optional filtering by relation type.",
+    description=f"Retrieves all links in the system, with optional filtering by relation type. Max limit: {MAX_LIMIT}, default: {DEFAULT_LIMIT}",
     responses={
+        200: {"model": PaginatedLinksResponse, "description": "Complete page of results"},
+        206: {
+            "model": PaginatedLinksResponse,
+            "description": "Partial results, more available via Link header",
+        },
+        400: {"model": ErrorResponse, "description": "Bad Request - Invalid parameters"},
         500: {"model": ErrorResponse, "description": "Internal server error"},
     },
 )
 async def get_all_links(
     request: Request,
     relation: Optional[RelationType] = None,
-    limit: int = 100,
+    limit: int = DEFAULT_LIMIT,
     cursor: Optional[str] = None,
     link_manager: LinkManager = Depends(get_link_manager),
-) -> List[BlockLink]:
+):
     """
-    Retrieves all links in the system.
+    Retrieves all links in the system with proper pagination.
 
     Parameters:
     - relation: Optional filter by relation type
-    - limit: Maximum number of results to return (default: 100)
-    - cursor: Optional pagination cursor
+    - limit: Maximum number of results to return (default: 100, max: 1000)
+    - cursor: Optional pagination cursor (opaque token)
+
+    Returns:
+    - HTTP 200: Complete page (no more results)
+    - HTTP 206: Partial page (more results available)
+    - Includes RFC-5988 Link header for next page when applicable
     """
     try:
-        # Build query with provided filters
-        query = LinkQuery()
-        if relation:
-            query = query.relation(relation)
-        query = query.limit(limit)
-        if cursor:
-            query = query.cursor(cursor)
-
-        # Get all links
-        result = link_manager.get_all_links(query=query)
-
-        return result.links
-
+        return await _paginate_links(
+            request=request,
+            query_fn=link_manager.get_all_links,
+            link_manager=link_manager,
+            relation=relation,
+            limit=limit,
+            cursor=cursor,
+        )
+    except HTTPException:
+        # Re-raise HTTP exceptions as-is
+        raise
     except Exception as e:
         # Log unexpected errors
         logger.exception(f"Unexpected error retrieving all links: {e}")
@@ -221,10 +373,12 @@ async def delete_link(
 
 @router.get(
     "/links/from/{block_id}",
-    response_model=List[BlockLink],
+    response_model=PaginatedLinksResponse,
     summary="Get links from a block",
-    description="Retrieves all links originating from a specific block, with optional filtering.",
+    description=f"Retrieves all links originating from a specific block, with optional filtering. Max limit: {MAX_LIMIT}",
     responses={
+        200: {"model": PaginatedLinksResponse, "description": "Complete page of results"},
+        206: {"model": PaginatedLinksResponse, "description": "Partial results, more available"},
         400: {"model": ErrorResponse, "description": "Bad Request - Invalid parameters"},
         500: {"model": ErrorResponse, "description": "Internal server error"},
     },
@@ -235,62 +389,40 @@ async def get_links_from(
     relation: Optional[RelationType] = None,
     depth: Optional[int] = None,
     direction: Optional[str] = None,
-    limit: int = 100,
+    limit: int = DEFAULT_LIMIT,
     cursor: Optional[str] = None,
     link_manager: LinkManager = Depends(get_link_manager),
-) -> List[BlockLink]:
+):
     """
-    Retrieves links originating from a specific block.
+    Retrieves links originating from a specific block with proper pagination.
 
     Parameters:
     - block_id: ID of the source block
     - relation: Optional filter by relation type
     - depth: Optional maximum traversal depth
     - direction: Optional traversal direction ('outbound', 'inbound', 'both')
-    - limit: Maximum number of results to return
-    - cursor: Optional pagination cursor
+    - limit: Maximum number of results to return (default: 100, max: 1000)
+    - cursor: Optional pagination cursor (opaque token)
+
+    Returns:
+    - HTTP 200: Complete page (no more results)
+    - HTTP 206: Partial page (more results available)
     """
     try:
-        # Validate UUID
-        try:
-            uuid.UUID(block_id)
-        except ValueError:
-            raise HTTPException(
-                status_code=400, detail="Invalid UUID format: block_id must be a valid UUID string"
-            )
-
-        # Validate direction if provided
-        if direction:
-            try:
-                # Get the Direction enum object, not just its value
-                direction_enum = Direction.from_string(direction)
-            except ValueError as e:
-                raise HTTPException(status_code=400, detail=str(e))
-
-        # Build query with provided filters
-        query = LinkQuery()
-        if relation:
-            query = query.relation(relation)
-        if depth:
-            query = query.depth(depth)
-        if direction:
-            # Pass the enum object, not the string value
-            query = query.direction(direction_enum)
-        query = query.limit(limit)
-        if cursor:
-            query = query.cursor(cursor)
-
-        # Get links
-        result = link_manager.links_from(block_id=block_id, query=query)
-
-        return result.links
-
+        return await _paginate_links(
+            request=request,
+            query_fn=link_manager.links_from,
+            link_manager=link_manager,
+            block_id=block_id,
+            relation=relation,
+            depth=depth,
+            direction=direction,
+            limit=limit,
+            cursor=cursor,
+        )
     except HTTPException:
         # Re-raise HTTPExceptions as-is (for validation errors)
         raise
-    except ValueError as e:
-        # Handle validation errors
-        raise HTTPException(status_code=400, detail=f"Validation error: {str(e)}")
     except Exception as e:
         # Log unexpected errors
         logger.exception(f"Unexpected error retrieving links: {e}")
@@ -299,10 +431,12 @@ async def get_links_from(
 
 @router.get(
     "/links/to/{block_id}",
-    response_model=List[BlockLink],
+    response_model=PaginatedLinksResponse,
     summary="Get links to a block",
-    description="Retrieves all links pointing to a specific block, with optional filtering.",
+    description=f"Retrieves all links pointing to a specific block, with optional filtering. Max limit: {MAX_LIMIT}",
     responses={
+        200: {"model": PaginatedLinksResponse, "description": "Complete page of results"},
+        206: {"model": PaginatedLinksResponse, "description": "Partial results, more available"},
         400: {"model": ErrorResponse, "description": "Bad Request - Invalid parameters"},
         500: {"model": ErrorResponse, "description": "Internal server error"},
     },
@@ -313,62 +447,40 @@ async def get_links_to(
     relation: Optional[RelationType] = None,
     depth: Optional[int] = None,
     direction: Optional[str] = None,
-    limit: int = 100,
+    limit: int = DEFAULT_LIMIT,
     cursor: Optional[str] = None,
     link_manager: LinkManager = Depends(get_link_manager),
-) -> List[BlockLink]:
+):
     """
-    Retrieves links pointing to a specific block.
+    Retrieves links pointing to a specific block with proper pagination.
 
     Parameters:
     - block_id: ID of the target block
     - relation: Optional filter by relation type
     - depth: Optional maximum traversal depth
     - direction: Optional traversal direction ('outbound', 'inbound', 'both')
-    - limit: Maximum number of results to return
-    - cursor: Optional pagination cursor
+    - limit: Maximum number of results to return (default: 100, max: 1000)
+    - cursor: Optional pagination cursor (opaque token)
+
+    Returns:
+    - HTTP 200: Complete page (no more results)
+    - HTTP 206: Partial page (more results available)
     """
     try:
-        # Validate UUID
-        try:
-            uuid.UUID(block_id)
-        except ValueError:
-            raise HTTPException(
-                status_code=400, detail="Invalid UUID format: block_id must be a valid UUID string"
-            )
-
-        # Validate direction if provided
-        if direction:
-            try:
-                # Get the Direction enum object, not just its value
-                direction_enum = Direction.from_string(direction)
-            except ValueError as e:
-                raise HTTPException(status_code=400, detail=str(e))
-
-        # Build query with provided filters
-        query = LinkQuery()
-        if relation:
-            query = query.relation(relation)
-        if depth:
-            query = query.depth(depth)
-        if direction:
-            # Pass the enum object, not the string value
-            query = query.direction(direction_enum)
-        query = query.limit(limit)
-        if cursor:
-            query = query.cursor(cursor)
-
-        # Get links
-        result = link_manager.links_to(block_id=block_id, query=query)
-
-        return result.links
-
+        return await _paginate_links(
+            request=request,
+            query_fn=link_manager.links_to,
+            link_manager=link_manager,
+            block_id=block_id,
+            relation=relation,
+            depth=depth,
+            direction=direction,
+            limit=limit,
+            cursor=cursor,
+        )
     except HTTPException:
         # Re-raise HTTPExceptions as-is (for validation errors)
         raise
-    except ValueError as e:
-        # Handle validation errors
-        raise HTTPException(status_code=400, detail=f"Validation error: {str(e)}")
     except Exception as e:
         # Log unexpected errors
         logger.exception(f"Unexpected error retrieving links: {e}")


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/4eec01e6-eeed-4dc3-b5a8-40b7bb4c7a2a)


No pagination on blocks yet, even though it should have it... started to build it, and the api crashed, so I stopped :) 

## Summary
**Fixed frontend pagination bug** where only 100 links were visible by implementing cursor-based pagination for all links API endpoints (`/links`, `/links/from/{id}`, `/links/to/{id}`).

## Key Changes
🎯 **Primary Fix**: Cursor-based pagination with OFFSET/LIMIT support for 165+ total links with configurable page sizes

📈 **Supplemental Improvements**:
- **Enhanced Response Structure**: `PaginatedLinksResponse` envelope with proper HTTP status codes (200/206) and RFC-5988 Link headers
- **Input Validation**: Robust server-side validation for limits (max 1000), cursor format, UUIDs, and direction parameters
- **Complete Test Coverage**: 13 new pagination tests + fixed 10 existing tests (39 total passing)

## Technical Details
- **Files**: 3 changed (+648/-171 lines)
- **DRY**: Extracted shared `_paginate_links()` helper function
- **Compatibility**: All existing functionality preserved, only response envelope changed

**Result**: Frontend can now efficiently navigate through large link datasets with proper pagination controls.