### PR TITLE
Add agents.md with uv-based tox instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS Guidelines
+
+This repository uses **AGENTS.md** files to guide AI-assisted contributions. Follow these practices unless a nested `AGENTS.md` overrides them.
+
+## Core Principles
+- Follow the [CogniDAO Charter](CHARTER.md) and the git-cogni spirit guide.
+- Keep changes minimal and purposeful. Complexity must be justified.
+- Untested code is untrusted code. Add tests for all non-trivial changes.
+- Commit messages are contracts: ensure each message accurately reflects its diff.
+
+These principles are outlined in `data/memory_banks/core/main/guide_git-cogni.md` lines 22-38.
+
+## Setup
+Run the development setup script once to install dependencies and pre-commit hooks:
+
+```bash
+./scripts/setup_dev_environment.sh
+```
+
+## Linting
+Run Ruff and other pre-commit checks before committing:
+
+```bash
+pre-commit run -a
+```
+
+## Testing
+Execute the full test suite with [Tox](https://tox.wiki/) via `uv`:
+
+```bash
+uv run tox
+```
+
+You can run a specific suite with `uv run tox -e <env>`.
+Valid environments include `infra_core`, `mcp_server`, `web_api` and `integration` (see README lines 54–63).
+
+## Pull Requests
+- Reference lines in files when summarizing changes.
+- Ensure tests pass and linting is clean.
+- Keep each PR focused on a single topic.
+
+

--- a/libs/infra_core/AGENTS.md
+++ b/libs/infra_core/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS Guidelines: infra_core
+
+This directory contains the core infrastructure library.
+
+Follow the repository [AGENTS.md](../AGENTS.md) for general rules. When working in `libs/infra_core`:
+
+- Run the infra_core test suite before committing:
+
+```bash
+uv run tox -e infra_core
+```
+
+- Maintain the library's pyproject dependencies. Update tests when adding features.
+
+
+

--- a/services/mcp_server/AGENTS.md
+++ b/services/mcp_server/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS Guidelines: mcp_server
+
+Follow the root [AGENTS.md](../../AGENTS.md).
+
+Run this service's tests before committing:
+
+```bash
+uv run tox -e mcp_server
+```
+
+

--- a/services/prefect_worker/AGENTS.md
+++ b/services/prefect_worker/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS Guidelines: prefect_worker
+
+Follow the root [AGENTS.md](../../AGENTS.md). No dedicated tests yet, but ensure changes do not break other services.
+
+

--- a/services/web_api/AGENTS.md
+++ b/services/web_api/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS Guidelines: web_api
+
+Follow the root [AGENTS.md](../../AGENTS.md).
+
+Run this service's tests before committing:
+
+```bash
+uv run tox -e web_api
+```
+
+


### PR DESCRIPTION
## Summary
- clarify that tox should be run through `uv`
- document valid tox environments
- update service AGENTS guides to use `uv run tox`

## Testing
- `uv run pre-commit run -a`
- `uv run tox -q` *(fails: protobuf/opentelemetry import error)*

------
https://chatgpt.com/codex/tasks/task_e_6866e369aa348320bc74499a668cd11a

![image](https://github.com/user-attachments/assets/39908c77-c60a-45a3-8da3-ff08b6b6035b)
